### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/dist/forage-query.js
+++ b/dist/forage-query.js
@@ -8,7 +8,7 @@
     // Node. Does not work with strict CommonJS, but
     // only CommonJS-like environments that support module.exports,
     // like Node.
-    module.exports = factory(require("localforage"),require("lodash"),require("node-uuid"));
+    module.exports = factory(require("localforage"),require("lodash"),require("uuid"));
   } else {
     factory(localforage,_,uuid);
   }

--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
   "homepage": "https://github.com/lykmapipo/forage-query",
   "author": "Lally Elias",
   "main": "dist/forage-query.js",
-  "contributors": [{
-    "name": "lykmapipo",
-    "github": "https://github.com/lykmapipo"
-  }],
+  "contributors": [
+    {
+      "name": "lykmapipo",
+      "github": "https://github.com/lykmapipo"
+    }
+  ],
   "keywords": [
     "localForage",
     "finder",
@@ -23,7 +25,7 @@
   "dependencies": {
     "localforage": "^1.4.0",
     "lodash": "^4.7.0",
-    "node-uuid": "^1.4.7"
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "chai": "^1.10.0",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.